### PR TITLE
Added default authorized_keys path for Darwin runtime

### DIFF
--- a/internal/command/exec.go
+++ b/internal/command/exec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"runtime"
 	"sort"
 
 	"github.com/hashicorp/go-set/v2"
@@ -47,8 +48,16 @@ type exec struct {
 func (e *exec) Execute(args config.Arguments) error {
 	switch args.AuthorizedKeys {
 	case "":
-		args.AuthorizedKeys = filepath.Join("/home", args.SystemUser, ".ssh", "authorized_keys")
-		e.logger.Printf("using default output authorized_keys file (%s)", args.AuthorizedKeys)
+		// check if mac or linux and use different location
+		if runtime.GOOS == "darwin" {
+			args.AuthorizedKeys = filepath.Join("/Users", args.SystemUser, ".ssh", "authorized_keys")
+			fmt.Println("Hello from macos")
+		} else {
+			args.AuthorizedKeys = filepath.Join("/home", args.SystemUser, ".ssh", "authorized_keys")
+			fmt.Println("Hello from else")
+			e.logger.Printf("using default output authorized_keys file (%s)", args.AuthorizedKeys)
+		}
+
 	default:
 		e.logger.Printf("using configured output authorized_keys file (%s)", args.AuthorizedKeys)
 	}

--- a/internal/command/exec.go
+++ b/internal/command/exec.go
@@ -51,10 +51,8 @@ func (e *exec) Execute(args config.Arguments) error {
 		// check if mac or linux and use different location
 		if runtime.GOOS == "darwin" {
 			args.AuthorizedKeys = filepath.Join("/Users", args.SystemUser, ".ssh", "authorized_keys")
-			fmt.Println("Hello from macos")
 		} else {
 			args.AuthorizedKeys = filepath.Join("/home", args.SystemUser, ".ssh", "authorized_keys")
-			fmt.Println("Hello from else")
 			e.logger.Printf("using default output authorized_keys file (%s)", args.AuthorizedKeys)
 		}
 


### PR DESCRIPTION
Hi I have added a small change for checking if the binary is run on macos, then the correct default authorized_keys path will be used. Issue was mentioned in #63 